### PR TITLE
exit argument for exiting modalka on key press.

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,11 +214,20 @@ adopt:
 (modalka-define-kbd "e" "C-e")
 (modalka-define-kbd "f" "C-f")
 (modalka-define-kbd "g" "C-g")
-(modalka-define-kbd "n" "C-n")
-(modalka-define-kbd "p" "C-p")
 (modalka-define-kbd "w" "C-w")
 (modalka-define-kbd "y" "C-y")
 (modalka-define-kbd "SPC" "C-SPC")
+
+(modalka-define-kbd-command "n" #'next-line)
+(modalka-define-kbd-command "p" #'previous-line)
+```
+
+You can also set the optional `exit` argument to `t` in order to exit
+`modalka-mode` before the command is run.
+
+```emacs-lisp
+(modalka-define-kbd "E" "C-e" t)
+(modalka-define-kbd-command "K" #'kill-whole-line t)
 ```
 
 For now you can use <kbd>M-x modalka-mode</kbd> to try it. When in normal
@@ -263,15 +272,20 @@ describes how to set up efficient modal editing and provides some tips.
 There is a set of functions to define key translations and to remove them:
 
 * `modalka-define-key`
+* `modalka-define-key-command`
 * `modalka-remove-key`
 
 Here are versions that wrap arguments with `kbd`:
 
 * `modalka-define-kbd`
+* `modalka-define-kbd-command`
 * `modalka-remove-kbd`
 
-Using these functions it's easy to setup your translation map. Note that
-target key binding cannot be prefix key (prefix keys will be ignored).
+Using these functions it's easy to setup your translation map, or just bind keys
+to commands. By setting the optional `exit` argument to `t`, `modalka-mode` will
+exit when the key is pressed. This is useful for commands where you want to edit
+text after running the command. Note that target key binding cannot be prefix
+key (prefix keys will be ignored).
 
 ### How to activate the minor mode
 

--- a/modalka.el
+++ b/modalka.el
@@ -126,7 +126,7 @@ If EXIT is t, exit `modalka-mode' before running COMMAND."
 (defun modalka-define-kbd-command (kbd-key command &optional exit)
   "Register KBD-KEY to COMMAND.
 If EXIT is t, exit `modalka-mode' before running COMMAND."
-  (modalka-define-kbd-command (kbd kbd-key) command exit))
+  (modalka-define-key-command (kbd kbd-key) command exit))
 
 ;;;###autoload
 (defun modalka-remove-key (key)

--- a/modalka.el
+++ b/modalka.el
@@ -4,7 +4,7 @@
 ;;
 ;; Author: Mark Karpov <markkarpov@openmailbox.org>
 ;; URL: https://github.com/mrkkrp/modalka
-;; Version: 0.1.4
+;; Version: 0.1.5
 ;; Package-Requires: ((emacs "24.4"))
 ;; Keywords: modal editing
 ;;
@@ -75,8 +75,9 @@ This variable is considered when Modalka is enabled globally via
   "This is Modalka mode map, used to translate your keys.")
 
 ;;;###autoload
-(defun modalka-define-key (actual-key target-key)
-  "Register translation from ACTUAL-KEY to TARGET-KEY."
+(defun modalka-define-key (actual-key target-key &optional exit)
+  "Register translation from ACTUAL-KEY to TARGET-KEY.
+If EXIT is t, exit `modalka-mode' before running TARGET-KEY function."
   (define-key
     modalka-mode-map
     actual-key
@@ -86,6 +87,8 @@ This variable is considered when Modalka is enabled globally via
         (let ((binding (key-binding target-key)))
           (unless (or (memq binding '(nil undefined))
                       (keymapp binding))
+            (when (and exit modalka-mode)
+              (modalka-mode -1))
             (call-interactively binding))))
       `(format "This command translates %s into %s, which calls `%s'."
                (key-description ,actual-key)
@@ -93,12 +96,37 @@ This variable is considered when Modalka is enabled globally via
                (key-binding     ,target-key)))))
 
 ;;;###autoload
-(defun modalka-define-kbd (actual-kbd target-kbd)
+(defun modalka-define-kbd (actual-kbd target-kbd &optional exit)
   "Register translation from ACTUAL-KBD to TARGET-KBD.
+If EXIT is t, exit `modalka-mode' before running TARGET-KBD function.
 
 Arguments are accepted in in the format used for saving keyboard
 macros (see `edmacro-mode')."
-  (modalka-define-key (kbd actual-kbd) (kbd target-kbd)))
+  (modalka-define-key (kbd actual-kbd) (kbd target-kbd) exit))
+
+;;;###autoload
+(defun modalka-define-key-command (key command &optional exit)
+  "Register KEY to COMMAND.
+If EXIT is t, exit `modalka-mode' before running COMMAND."
+  (if exit
+      (define-key
+        modalka-mode-map
+        key
+        (defalias (make-symbol (concat "modalka-exit-then-"
+                                       (symbol-name command)))
+          (lambda ()
+            (interactive)
+            (modalka-mode -1)
+            (call-interactively command))
+          `(format "Exit `modalka-mode', then run original command:\n\n%s"
+                   ,(documentation ,command))))
+    (define-key modalka-mode-map key command)))
+
+;;;###autoload
+(defun modalka-define-kbd-command (kbd-key command &optional exit)
+  "Register KBD-KEY to COMMAND.
+If EXIT is t, exit `modalka-mode' before running COMMAND."
+  (modalka-define-kbd-command (kbd kbd-key) command exit))
 
 ;;;###autoload
 (defun modalka-remove-key (key)


### PR DESCRIPTION
Exit arguments make it easy to exit Modalka before running a specific command. More information provided in the updated README.

Also added the functions:

- modalka-define-key-command
- modalka-define-kbd-command

This way the exit argument can be used for commands, and not only
translations, since just adding the commands to modalka-mode-map will
not provide the optional exit argument.