### PR TITLE
Make keymap an optional argument of modalka-define-key

### DIFF
--- a/modalka.el
+++ b/modalka.el
@@ -75,10 +75,13 @@ This variable is considered when Modalka is enabled globally via
   "This is Modalka mode map, used to translate your keys.")
 
 ;;;###autoload
-(defun modalka-define-key (actual-key target-key)
-  "Register translation from ACTUAL-KEY to TARGET-KEY."
+(defun modalka-define-key (actual-key target-key &optional keymap)
+  "Register translation from ACTUAL-KEY to TARGET-KEY.
+
+If the optional argument keymap is given register the translation in
+KEYMAP instead of the default keymap."
   (define-key
-    modalka-mode-map
+    (if keymap keymap modalka-mode-map)
     actual-key
     (defalias (make-symbol "modalka-translation")
       (lambda ()


### PR DESCRIPTION
With an optional keymap argument it is possible to also create prefix
commands in "normal" mode. Eg. like a mapping from `x s` to `C-x C-s`:

```emacs-lisp
(let* ((keymap (define-prefix-command 'modalka-Control-X-prefix)))
  (define-key modalka-mode-map (kbd "x") keymap)
  (modalka-define-key (kbd "s") (kbd "C-x C-s") keymap))
```

Note, that I am by no means an Emacs wizard, so it is quite possible
that this can be achieved much simpler or cleaner or is a total stupid
idea altogether.

Related to #25.